### PR TITLE
Changed dash to underscore

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ One the plugin has been installed, it may be enabled inside your Gruntfile with 
 grunt.loadNpmTasks('grunt-sass-convert');
 ```
 
-## The "sass-convert" task
+## The "sass_convert" task
 This plugin requires [sass-convert](http://sass-lang.com/docs/yardoc/) installed. If you have alredy installed [Sass](http://sass-lang.com/), you might have already installed sass-convert also.
 
 ### Overview
-In your project's Gruntfile, add a section named `sass-convert` to the data object passed into `grunt.initConfig()`.
+In your project's Gruntfile, add a section named `sass_convert` to the data object passed into `grunt.initConfig()`.
 
 ```js
 grunt.initConfig({
-  sass-convert: {
+  sass_convert: {
     options: {
       // command line options here
     },
@@ -66,7 +66,7 @@ formatted scss files ('''caution: override your scss files''')
 
 ```js
 grunt.initConfig({
-  sass-convert: {
+  sass_convert: {
     files: {
       src: ['path/**/*.scss']
     }
@@ -80,7 +80,7 @@ if you want to save formatted files to the another location, use dest property.
 
 ```js
 grunt.initConfig({
-  sass-convert: {
+  sass_convert: {
     options: {
       indent: 4
     },

--- a/tasks/sass-convert.js
+++ b/tasks/sass-convert.js
@@ -11,7 +11,7 @@ module.exports = function (grunt) {
   // creation: http://gruntjs.com/creating-tasks
   'use strict';
 
-  grunt.registerMultiTask('sass-convert', 'just execute sass-convert', function () {
+  grunt.registerMultiTask('sass_convert', 'just execute sass-convert', function () {
     var cb = this.async();
 
     var options = this.options({


### PR DESCRIPTION
Changing the dash to an underscore got rid of the syntax error for me.  Changed it in the docs too.

It got rid of this issue:  https://github.com/memolog/grunt-sass-convert/issues/1
