### PR TITLE
BUG: Origin path prefixed to output path

### DIFF
--- a/tasks/sass-convert.js
+++ b/tasks/sass-convert.js
@@ -29,7 +29,10 @@ module.exports = function (grunt) {
       args.push(src);
 
       if (files.dest) {
-        out = files.dest + '/' + src.replace(/\.(css|scss|sass)/, '.' + options.to);
+        var srcPath = src.split('/'),
+            fileName = srcPath[srcPath.length - 1];
+
+        out = files.dest + fileName.replace(/\.(css|scss|sass)/, '.' + options.to);
       }
       var sass = grunt.util.spawn({
         cmd: 'sass-convert',


### PR DESCRIPTION
EG: 

```
files: {
        src: [
            'build/*.css',
        ],
        dest: 'sass/components/_'
    }
```

Will output files to:

```
sass/components/_build/*.scss
```

Expected result:

```
sass/components/_*.scss
```

Destinations can be supplied in full to achieve the original outcome, but it is currently not possible to remove the src path from the destination path without this fix.
